### PR TITLE
DOC info for smORF files

### DIFF
--- a/macrel/main.py
+++ b/macrel/main.py
@@ -111,8 +111,9 @@ def validate_args(args):
     if not args.output and not args.output_file:
         error_exit(args, "Either --output or --file-output argument must be used")
 
-    if args.keep_fasta_headers and args.command != 'get-smorfs':
-        error_exit(args, '--keep-fasta-headers is only available for get-smorfs command')
+    # This makes the args.keep_fasta_headers be used in more modes
+    if args.keep_fasta_headers and args.command in ['peptides', 'abundance']:
+        error_exit(args, '--keep-fasta-headers is not available for peptides and abundance commands')
 
     args.output_dir = args.output
     if args.output_dir:

--- a/macrel/main.py
+++ b/macrel/main.py
@@ -111,7 +111,6 @@ def validate_args(args):
     if not args.output and not args.output_file:
         error_exit(args, "Either --output or --file-output argument must be used")
 
-    # This makes the args.keep_fasta_headers be used in more modes
     if args.keep_fasta_headers and args.command in ['peptides', 'abundance']:
         error_exit(args, '--keep-fasta-headers is not available for peptides and abundance commands')
 

--- a/macrel/output.py
+++ b/macrel/output.py
@@ -2,7 +2,7 @@ header = """If you find Macrel useful, please cite:
 
 > Santos-Junior, C.D. et al. Macrel: antimicrobial peptide screening in
 > genomes and metagenomes. The PeerJ 8:e10555
->  https://doi.org/10.7717/peerj.10555
+> https://doi.org/10.7717/peerj.10555
 
 For more information, please read [the macrel
 documentation](https://macrel.readthedocs.io) and use the [AMPsphere mailing
@@ -31,7 +31,8 @@ results.
 
 Note that, by default, only peptides predicted to be AMPs are output. If the
 `--keep-negatives` flag is used, however, all sequences will be present in the
-table."""
+table.
+"""
 
 predicted_faas_doc = """- `macrel.out.all_orfs.faa`
 
@@ -41,7 +42,39 @@ proteins).
 - `macrel.out.smorfs.faa`
 
 Fasta file containing the predicted small ORFs (length filtered ranging from 10
-to 100 amino acids)."""
+to 100 amino acids).
+
+In the both files the original header structure from Prodigal indicates the AMP
+gene origins, and is shown if the option `--keep-fasta-headers` is used. The 
+header structure has a consistent notation, e.g.:
+
+Header for the 2nd small protein in the contig k77_5:
+
+>k77_5_2 # 1984 # 2010 # 1 # ID=2_2;partial=00;
+start_type=ATG;rbs_motif=TAAAAAA;rbs_spacer=7bp;gc_cont=0.487
+
+The next three fields in the header, delimited by "#" signs, are the: (1) leftmost coordinate,
+(2) rightmost coordinate, and (3) the strand (1 for forward strand genes, -1 for reverse strand genes).
+
+Following the coordinate information is a semicolon-delimited string with he following fields:
+
+   - ID: unique identifier for each gene, consisting of the ordinal ID of the sequence and an ordinal ID of that
+         gene within the sequence (separated by an underscore).
+   
+   - partial: "0" indicates the gene has a true boundary (a start or a stop), whereas a "1" indicates the gene is
+              "unfinished" at that edge (i.e. a partial gene).
+   
+   - start_type: sequence of the start codon (usually ATG, GTG, TTG, or "Edge" if the gene has no start codon).
+   
+   - stop_type: sequence of the stop codon (usually TAA, TGA, TAG or "Edge" if the gene has no stop codon).
+   
+   - rbs_motif: RBS motif found by Prodigal (e.g. "AGGA" or "GGA", etc.)
+   
+   - rbs_spacer: number of bases between the start codon and the observed motif.
+   
+   - gc_cont: GC content of the gene sequence.
+   
+"""
 
 megahit_output_doc = """- `example_metag.megahit_output`
 


### PR DESCRIPTION
- Include headers info in output for `--keep-fasta-headers` option
- Make the option `--keep-fasta-headers` universal (not only for `get-smorfs` mode)