### PR TITLE
FIX bug in github actions // ENH update models to avoid scikit-learn version conflict

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -13,7 +13,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Setup miniconda
-      uses: conda-incubator/setup-miniconda@v3
+      uses: conda-incubator/setup-miniconda@v2
       with:
         miniconda-version: "latest"
  

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
     - name: Checking code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup miniconda
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         miniconda-version: "latest"
  

--- a/macrel/data/models/README.txt
+++ b/macrel/data/models/README.txt
@@ -1,0 +1,69 @@
+Load data
+Train RF with OOB estimators
+Train RF without OOB estimators
+Fitting models
+Save AMP model
+Predict test
+# AMP (unbalanced training) CLASSIFIER 
+Accuracy: 0.926
+MCC: 0.862
+
+Confusion matrix:
+[[784 136]
+ [  0 920]]
+
+              precision    recall  f1-score   support
+
+         AMP      1.000     0.852     0.920       920
+        NAMP      0.871     1.000     0.931       920
+
+    accuracy                          0.926      1840
+   macro avg      0.936     0.926     0.926      1840
+weighted avg      0.936     0.926     0.926      1840
+
+
+
+Load bench set
+Train bench set
+Test bench set
+# AMP (benchmark training) CLASSIFIER 
+Accuracy: 0.946
+MCC: 0.893
+
+Confusion matrix:
+[[846  74]
+ [ 26 894]]
+
+              precision    recall  f1-score   support
+
+         AMP      0.970     0.920     0.944       920
+        NAMP      0.924     0.972     0.947       920
+
+    accuracy                          0.946      1840
+   macro avg      0.947     0.946     0.946      1840
+weighted avg      0.947     0.946     0.946      1840
+
+
+
+Load datasets
+Fit Hemo sets
+Save Hemo model
+# Hemo CLASSIFIER 
+Accuracy: 0.936
+MCC: 0.873
+
+Confusion matrix:
+[[102   8]
+ [  6 104]]
+
+              precision    recall  f1-score   support
+
+        Hemo      0.944     0.927     0.936       110
+     NonHemo      0.929     0.945     0.937       110
+
+    accuracy                          0.936       220
+   macro avg      0.937     0.936     0.936       220
+weighted avg      0.937     0.936     0.936       220
+
+January 30th 2023
+scikit-learn 1.1.2

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-$PYTHON -m pip install --disable-pip-version-check --no-cache-dir --ignore-installed --no-deps --use-feature=in-tree-build -vv .
+$PYTHON -m pip install --disable-pip-version-check --no-cache-dir --ignore-installed --no-deps -vv .


### PR DESCRIPTION
Minor changes:

- Removed the deprecated flag '--features=in-tree-build' in the pip install command to avoid errors
  when setting up the environment

- Updated the version used in the GitHub Actions to v3 to avoid NodeJS conflicts with new CPUs
  GitHub use

- Updated models for AMP and Hemolytic peptide predictions, yet trained with the same data,
  but using a newer distribution of scikit-learn (v.1.1.2) to avoid warning messages and/or prediction
  inconsistencies. -- Results should be consistent with previous versions
